### PR TITLE
refs #12 - fixed a bug with LimitedTextField return key

### DIFF
--- a/InputKitSwift/LimitedTextField.swift
+++ b/InputKitSwift/LimitedTextField.swift
@@ -316,8 +316,8 @@ fileprivate class LimitedTextFieldDelegate: LimitedDelegate, UITextFieldDelegate
     @available(iOS 2.0, *)
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         var flag = true
-        if let realDelegate = self.realDelegate, realDelegate.responds(to: #selector(textFieldShouldClear(_:))) {
-            flag = realDelegate.textFieldShouldClear(textField)
+        if let realDelegate = self.realDelegate, realDelegate.responds(to: #selector(textFieldShouldReturn(_:))) {
+          flag = realDelegate.textFieldShouldReturn(textField)
         }
         return flag
     }// called when 'return' key pressed. return NO to ignore.


### PR DESCRIPTION
I have noticed that if I set delegate of my text field and then tap 'return' key it does not come into my textFieldShouldReturn method. So, I looked into source codes and found small yet annoying typo