### PR TITLE
Configurable float separators

### DIFF
--- a/InputKitSwift.podspec
+++ b/InputKitSwift.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => "MIT", :file => "LICENSE" }
   s.author             = { "tingxins" => "tingxins@sina.com" }
   s.platform     = :ios, "8.0"
-  s.source       = { :git => "https://github.com/tingxins/InputKit.git", :tag => 'v1.1.19' }
+  s.source       = { :git => "https://github.com/tingxins/InputKit.git", :tag => 'v1.1.20' }
   s.source_files  = 'InputKitSwift/**/*.{swift}'
   s.requires_arc = true
   end

--- a/InputKitSwift/MatchConstant.swift
+++ b/InputKitSwift/MatchConstant.swift
@@ -24,3 +24,6 @@ public struct MatchConstant {
     }
 }
 
+public enum MatchVariables {
+  public static var kLimitedTextNumberFloatSeparators = "."
+}

--- a/InputKitSwift/MatchManager.swift
+++ b/InputKitSwift/MatchManager.swift
@@ -10,18 +10,18 @@ import Foundation
 
 internal class MatchManager {
     
-    class func matchLimitedTextTypePrice(component:AnyObject, value: String) -> Bool {
-        
-        guard let limitedPrefix = component.value(forKeyPath: "limitedPrefix") as? Int, let limitedSuffix = component.value(forKeyPath: "limitedSuffix") as? Int else {
-            return true
-        }
-        
-        let matchZero = NSPredicate(format: MatchHeader.Name.kRegExHeader, MatchConstant.Name.kLimitedTextZeroRegEx)
-        let matchValue = NSPredicate(format: MatchHeader.Name.kRegExHeader, "^\\d{0,\(limitedPrefix)}$|^(\\d{0,\(limitedPrefix)}[.][0-9]{0,\(limitedSuffix)})$")
-        let isZero = !matchZero.evaluate(with: value)
-        let isCorrectValue = matchValue.evaluate(with: value)
-        return isZero && isCorrectValue ? true : false
+  class func matchLimitedTextTypePrice(component:AnyObject, value: String) -> Bool {
+    
+    guard let limitedPrefix = component.value(forKeyPath: "limitedPrefix") as? Int, let limitedSuffix = component.value(forKeyPath: "limitedSuffix") as? Int else {
+      return true
     }
+    
+    let matchZero = NSPredicate(format: MatchHeader.Name.kRegExHeader, MatchConstant.Name.kLimitedTextZeroRegEx)
+    let matchValue = NSPredicate(format: MatchHeader.Name.kRegExHeader, "^\\d{0,\(limitedPrefix)}$|^(\\d{0,\(limitedPrefix)}[\(MatchVariables.kLimitedTextNumberFloatSeparators)][0-9]{0,\(limitedSuffix)})$")
+    let isZero = !matchZero.evaluate(with: value)
+    let isCorrectValue = matchValue.evaluate(with: value)
+    return isZero && isCorrectValue ? true : false
+  }
     
     class func matchLimitedTextTypeCustom(regEx: String, component: AnyObject, value: String) -> Bool {
         let matchValue = NSPredicate(format: MatchHeader.Name.kRegExHeader, regEx)


### PR DESCRIPTION
![img_1141](https://user-images.githubusercontent.com/7995896/41387132-834b1cc0-6faf-11e8-8105-ff3460c1e17b.PNG)
as you see on the attached screenshot russian locale uses ',' on numeric keyboard thus does not allow float values. As a workaround i created a separate enum for float separator and updated price matching method. 
In my app I overwrite separators like: 
`MatchVariables.kLimitedTextNumberFloatSeparators = ".,"`